### PR TITLE
Fix Username Handling with Spaces and Enhance Settings Isolation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createDeletionRequestMarkerFormWindow } from "./modules/deletionrequestmaker";
 import { createBlockAppealsButton, createButton, createDRCButton, createHideButton, createNoticeboardResolutionButtons } from "./utils/DOMutils";
-import { isDeletionRequestOpen, currentAction, currentNamespace, currentPageName, currentSkin, currentUser, diffNewId, getConfigPage, isCurrentUserSysop, isMainPage } from "./utils/utils";
+import { isDeletionRequestOpen, currentAction, currentNamespace, currentPageName, currentPageNameNoUnderscores, currentSkin, currentUser, diffNewId, getConfigPage, isCurrentUserSysop, isMainPage } from "./utils/utils";
 import { createSpeedyDeletionFormWindow } from "./modules/speedydeletion";
 import { createPageProtectionFormWindow } from "./modules/pageprotection";
 import { createTagsFormWindow } from "./modules/tags";
@@ -139,7 +139,7 @@ if (!window.IS_TWINKLE_LITE_LOADED) {
 			})
 		}
 
-		if (currentNamespace == 2 && currentPageName.endsWith(currentUser)) {
+		if (currentNamespace == 2 && currentPageNameNoUnderscores.endsWith(currentUser)) {
 			const configLink = mw.util.addPortletLink(menu, 'javascript:void(0)', 'Configuración de TL', 'TL-button', 'Configuración de Twinkle Lite')
 			if (configLink) {
 				configLink.onclick = () => createConfigWindow(settings);

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -28,7 +28,7 @@ async function editConfigPage(settings: Settings) {
 function saveSettingsToLocalStorage(settings: Settings) {
     try {
         const serializedSettings = JSON.stringify(settings);
-        localStorage.setItem("TwinkleLiteUserSettings", serializedSettings);
+        localStorage.setItem(`TwinkleLiteUserSettings_${currentUser}`, serializedSettings);
     } catch (error) {
         console.error("Hubo un error guardando las preferencias de configuración en el localStorage:", error)
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,15 +7,15 @@ import { QueryParams } from 'types-mediawiki/mw/Uri';
 export const api = new mw.Api()
 let cachedSettings: Settings | null = null;
 
-export const currentPageName = mw.config.get('wgPageName');
+export const currentPageName = mw.config.get('wgPageName') || '';
 export const currentPageNameNoUnderscores = currentPageName.replace(/_/g, ' ');
-export const currentUser = mw.config.get('wgUserName');
-export const relevantUserName = mw.config.get("wgRelevantUserName");
+export const currentUser = mw.config.get('wgUserName') || '';
+export const relevantUserName = mw.config.get("wgRelevantUserName") || '';
 export const currentNamespace: string | number = mw.config.get('wgNamespaceNumber');
 export const currentAction = mw.config.get('wgAction');
 export const currentSkin = mw.config.get('skin');
 export const diffNewId = mw.config.get('wgDiffNewId');
-export const userFlags: string[] = mw.config.get('wgUserGroups');
+export const userFlags: string[] = mw.config.get('wgUserGroups') || [];
 export const isCurrentUserSysop: boolean = userFlags.includes('sysop');
 export const isUserInMobileSkin = mw.config.get('skin') == 'minerva';
 export const isMainPage: boolean = mw.config.get('wgIsArticle');
@@ -491,7 +491,7 @@ export async function getConfigPage(): Promise<Settings | null> {
         return cachedSettings;
     }
 
-    const localStorageSettings: string | null = localStorage.getItem("TwinkleLiteUserSettings");
+    const localStorageSettings: string | null = localStorage.getItem(`TwinkleLiteUserSettings_${currentUser}`);
     if (localStorageSettings) {
         cachedSettings = JSON.parse(localStorageSettings);
         return cachedSettings;


### PR DESCRIPTION
This PR a critical issue where the Twinkle Lite configuration was failing to load or appear for users with spaces in their usernames (e.g., "Paco Editor"). Additionally, it implements several security and robustness improvements to ensure a more reliable user experience.

## Changes

### 1. Username Space Normalization
- **Issue:** The script compared `wgPageName` (underscores) with `wgUserName` (spaces), causing a mismatch on user pages for names with spaces.
- **Fix:** Switched to `currentPageNameNoUnderscores` for consistent comparison, ensuring the "Configuración de TL" link appears correctly for all users.

### 2. User-Specific Settings Isolation
- **Issue:** Previously, all users shared a single `TwinkleLiteUserSettings` key in `localStorage`, leading to settings leakage between different users on the same machine.
- **Fix:** Implemented user-specific `localStorage` keys using the format `TwinkleLiteUserSettings_${currentUser}`. This ensures each user's preferences are isolated.

### 3. Robust Configuration Access
- **Improvement:** Added safety guards to top-level `mw.config.get()` calls in `utils.ts`.
- **Details:** Prevented potential runtime `TypeError` crashes during early script execution by ensuring methods like `.replace()` and `.includes()` are called only on valid strings/arrays.

## Impact
- **Bug Fix:** Users with spaces in their names can now access and save their configuration.
- **Privacy/Security:** Settings are no longer shared between different users on the same browser session.
- **Reliability:** The script is more resilient to varying MediaWiki environment initialization states.

## Verification
- Verified that the "Configuración de TL" portlet link appears on user pages with spaces.
- Confirmed that settings saved for "User A" do not override settings for "User B" in the same browser.
- Validated that the script no longer crashes if `mw.config` values are briefly unavailable during load.